### PR TITLE
Removed a bad style broad exception

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -694,10 +694,16 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
             arr = parse_box2d(result)
             resbox = box(arr[0], arr[1], arr[2],
                          arr[3]) if not _is_point(arr) else Point(arr[0], arr[1])
-        except Exception:  # pragma: no cover # pylint: disable=broad-except
+        except ValueError as error:
             # We bail with True to be conservative and
             # not exclude this geometry from the result
-            # set. Only happens if result does not
-            # have a bbox
+            # set. should only happens if result does not have a bbox
+            logger.error(
+                'Failed to find the bbox intersection with ref=%s and result=%s, '
+                'bail with True to be conservative: %s',
+                ref,
+                result,
+                error
+            )
             return True
         return refbox.intersects(resbox)


### PR DESCRIPTION
The broad exception has been replaced by the eventuel possible
exception. In the try ... except block, the method `box()` and `Point()`
could trigger a TypeError exception if they did receive a wrong type
arguments but this should not happen, that's why this exception is not
catched. If this would happen we would find this out more quickly as the
request would failed with a 500.
In opposite if the results is an empty string (which apparently can
happen and is ok), the method `parse_box2d()` would raise a ValueError.
In this case we catch the exception, log an error an bail out with True.