### PR TITLE
BGDIINF_SB-2126: Fixed callback feature, added gzip compression and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,4 @@ The service is configured by Environment Variable:
 | FORWARDED_PROTO_HEADER_NAME | `X-Forwarded-Proto` | Sets gunicorn `secure_scheme_headers` parameter to `{FORWARDED_PROTO_HEADER_NAME: 'https'}`, see https://docs.gunicorn.org/en/stable/settings.html#secure-scheme-headers. |
 | SCRIPT_NAME | '' | The script name. This will be used once, when we have an idea about how to query search-wsgi later on. F.ex. `/api/search/` f.ex. used by gunicorn (wsgi-server). |
 | CACHE_CONTROL_HEADER | `'public, max-age=600'` | Cache-Control header value for the search endpoint |
+| GZIP_COMPRESSION_LEVEL | `9` | GZIP compression level |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,7 @@ def add_cors_header(response):
 
     response.headers['Access-Control-Allow-Methods'] = 'GET, HEAD, OPTIONS'
     response.headers['Access-Control-Allow-Headers'] = '*'
+    response.headers['Access-Control-Allow-Origin'] = "*"
     return response
 
 

--- a/app/helpers/validation_search.py
+++ b/app/helpers/validation_search.py
@@ -25,20 +25,6 @@ class MapNameValidation(object):  # pylint: disable=too-few-public-methods
             raise BadRequest(f'The map ({topic_name}) you provided does not exist')
 
 
-class BaseValidation(MapNameValidation):  # pylint: disable=too-few-public-methods
-
-    def __init__(self, request):
-        super().__init__()
-
-        self.topic_name = request.matchdict.get('topic')
-        self.has_topic(self.topic_name)
-        self.geodataStaging = request.registry.settings['geodata_staging']
-        self.cbName = request.params.get('callback')
-        self.request = request
-        self.lang = request.lang
-        self.translate = request.translate
-
-
 class SearchValidation(MapNameValidation):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, request):

--- a/app/routes.py
+++ b/app/routes.py
@@ -18,22 +18,25 @@ def checker():
 
 @app.route('/rest/services/<topic>/SearchServer', methods=['GET'])
 def search_server(topic='all'):
-    request.matchdict = {}
-    request.matchdict['topic'] = topic
-    search = Search(request)
-    if request.args.get('geometryFormat') == 'geojson':
-        response = make_response(search.view_find_geojson())
-        response.headers["Content-Type"] = "application/geo+json"
-    elif request.args.get('geometryFormat') == 'esrijson':
-        response = make_response(search.view_find_esrijson())
-    else:
-        response = make_response(search.search())
+    search = Search(request, topic)
+    content_type_override = None
 
-    # TODO: better - callback f.ex with a renderer
-    if request.args.get('callback'):
-        callback = request.args.get('callback')
-        data = response.json
-        response.headers["Content-Type"] = "application/javascript"
-        response.data = f"/**/{callback}({data}));"
+    if request.args.get('geometryFormat') == 'geojson':
+        results = search.view_find_geojson()
+        content_type_override = "application/geo+json"
+    elif request.args.get('geometryFormat') == 'esrijson':
+        results = search.view_find_esrijson()
+    else:
+        results = search.search()
+
+    response = make_response(jsonify(results))
+
+    callback = request.args.get('callback', None)
+    if callback is not None:
+        response.set_data(f"/**/{callback}({response.get_data(as_text=True)});")
+        content_type_override = "application/javascript"
+
+    if content_type_override:
+        response.headers['Content-Type'] = content_type_override
 
     return response

--- a/app/routes.py
+++ b/app/routes.py
@@ -34,7 +34,7 @@ def search_server(topic='all'):
     callback = request.args.get('callback', None)
     if callback is not None:
         response.set_data(f"/**/{callback}({response.get_data(as_text=True)});")
-        content_type_override = "application/javascript"
+        content_type_override = "text/javascript"
 
     if content_type_override:
         response.headers['Content-Type'] = content_type_override

--- a/app/search.py
+++ b/app/search.py
@@ -40,10 +40,10 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
     DEFAULT_SRID = 21781
     BBOX_SEARCH_LIMIT = 150
 
-    def __init__(self, request):
+    def __init__(self, request, topic):
         super().__init__(request)
 
-        self.topic_name = request.matchdict.get('topic')
+        self.topic_name = topic
         self.has_topic(self.topic_name)
 
         # treat lang, de as default

--- a/app/settings.py
+++ b/app/settings.py
@@ -76,7 +76,6 @@ CACHE_TYPE = 'SimpleCache'
 CACHE_DEFAULT_TIMEOUT = int(os.getenv('CACHE_DEFAULT_TIMEOUT', '86400'))  # 24 h
 
 # SQL Alchemy
-# pylint: disable=line-too-long
 SQLALCHEMY_DATABASE_URI = \
     f"postgresql://{BOD_DB_USER}:{BOD_DB_PASSWD}@{BOD_DB_HOST}:{BOD_DB_PORT}/{BOD_DB_NAME}"
 
@@ -92,3 +91,5 @@ FORWARDED_PROTO_HEADER_NAME = os.getenv('FORWARDED_PROTO_HEADER_NAME', 'X-Forwar
 
 # Cache-Control
 CACHE_CONTROL_HEADER = os.getenv('CACHE_CONTROL_HEADER', 'public, max-age=600')
+
+GZIP_COMPRESSION_LEVEL = int(os.getenv('GZIP_COMPRESSION_LEVEL', '9'))


### PR DESCRIPTION
The callback functionality did not contained a valid json content; used
    single quote instead of double quotes and special caracters where not
    escaped correctly, this was due to the fact that the python dictionary
    was printed instead of a json dump. Also removed superflous `)` the
    callback answer, this was making it an invalid javascript syntax.
    
    Clean up legacy Paramid framework variable `matchdict` that came from
    the legacy mf-chsdi3.

Also added gzip compression.

Added CORS allow origin header