### PR TITLE
BGDIINF_SB-2299: Improved performance by factor 7.5x using caching and pyproj.Transformer

### DIFF
--- a/app/helpers/helpers_search.py
+++ b/app/helpers/helpers_search.py
@@ -138,9 +138,16 @@ def transform_round_geometry(geom, srid_from, srid_to, rounding=True):
     return _transform_shape(geom, srid_from, srid_to, rounding=rounding)
 
 
-@cache.memoize(timeout=60)
+TRANSFORMER = {}
+
+
 def get_transformer(srid_from, srid_to):
-    return Transformer.from_crs(srid_from, srid_to, always_xy=True)
+    transformer_id = f'{srid_from}-to-{srid_to}'
+    if transformer_id in TRANSFORMER:
+        return TRANSFORMER[transformer_id]
+
+    TRANSFORMER[transformer_id] = Transformer.from_crs(srid_from, srid_to, always_xy=True)
+    return TRANSFORMER[transformer_id]
 
 
 # used by transform_round_geometry used by search.py

--- a/app/helpers/helpers_search.py
+++ b/app/helpers/helpers_search.py
@@ -2,12 +2,11 @@ import logging
 import math
 import unicodedata
 from decimal import Decimal
-from functools import partial
 from functools import reduce
 
 import pyproj.exceptions
 from pyproj import Proj
-from pyproj import transform as proj_transform
+from pyproj import Transformer
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform as shape_transform
 from shapely.wkt import dumps as shape_dumps
@@ -124,12 +123,6 @@ def round_geometry_coordinates(geom, precision=None):
     return geom
 
 
-def _transform_point(coords, srid_from, srid_to):
-    proj_in = get_proj_from_srid(srid_from)
-    proj_out = get_proj_from_srid(srid_to)
-    return proj_transform(proj_in, proj_out, coords[0], coords[1], always_xy=True)
-
-
 @cache.memoize(timeout=60)
 def transform_round_geometry(geom, srid_from, srid_to, rounding=True):
     if srid_from == srid_to:
@@ -145,6 +138,11 @@ def transform_round_geometry(geom, srid_from, srid_to, rounding=True):
     return _transform_shape(geom, srid_from, srid_to, rounding=rounding)
 
 
+@cache.memoize(timeout=60)
+def get_transformer(srid_from, srid_to):
+    return Transformer.from_crs(srid_from, srid_to, always_xy=True)
+
+
 # used by transform_round_geometry used by search.py
 # Reprojecting pairs of coordinates and rounding them if necessary
 # Only a point or a line are considered
@@ -153,10 +151,11 @@ def _transform_coordinates(coordinates, srid_from, srid_to, rounding=True):
         logger.error("Invalid coordinates %s, must be two numbers", coordinates)
         raise ValueError(f"Invalid coordinates {coordinates}, must be two numbers")
     new_coords = []
+    transformer = get_transformer(srid_from, srid_to)
     coords_iter = iter(coordinates)
     try:
         for pnt in zip(coords_iter, coords_iter):
-            new_pnt = _transform_point(pnt, srid_from, srid_to)
+            new_pnt = transformer.transform(pnt[0], pnt[1])
             new_coords += new_pnt
         if rounding:
             precision = get_precision_for_proj(srid_to)
@@ -173,12 +172,9 @@ def _transform_coordinates(coordinates, srid_from, srid_to, rounding=True):
 
 # indirectly used by search.py
 def _transform_shape(geom, srid_from, srid_to, rounding=True):
-    proj_in = get_proj_from_srid(srid_from)
-    proj_out = get_proj_from_srid(srid_to)
+    transformer = get_transformer(srid_from, srid_to)
 
-    projection_func = partial(proj_transform, proj_in, proj_out, always_xy=True)
-
-    new_geom = shape_transform(projection_func, geom)
+    new_geom = shape_transform(transformer.transform, geom)
     if rounding:
         precision = get_precision_for_proj(srid_to)
         return _round_shape_coordinates(new_geom, precision=precision)

--- a/app/helpers/helpers_search.py
+++ b/app/helpers/helpers_search.py
@@ -13,6 +13,8 @@ from shapely.ops import transform as shape_transform
 from shapely.wkt import dumps as shape_dumps
 from shapely.wkt import loads as shape_loads
 
+from app import cache
+
 logger = logging.getLogger(__name__)
 
 # pylint: disable=invalid-name
@@ -128,6 +130,7 @@ def _transform_point(coords, srid_from, srid_to):
     return proj_transform(proj_in, proj_out, coords[0], coords[1], always_xy=True)
 
 
+@cache.memoize(timeout=60)
 def transform_round_geometry(geom, srid_from, srid_to, rounding=True):
     if srid_from == srid_to:
         if rounding:

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -8,7 +8,6 @@ from shapely.geometry import mapping
 from app.helpers.helpers_search import _round_bbox_coordinates
 from app.helpers.helpers_search import _round_shape_coordinates
 from app.helpers.helpers_search import _transform_coordinates
-from app.helpers.helpers_search import _transform_point
 from app.helpers.helpers_search import _transform_shape
 from app.helpers.helpers_search import center_from_box2d
 from app.helpers.helpers_search import escape_sphinx_syntax
@@ -80,13 +79,6 @@ class TestHelpers(TestCase):
         str_proj_lv03 = '+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 ' \
         '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +units=m +no_defs'
         self.assertEqual(proj.srs, str_proj_lv03)
-
-    def test__transform_point(self):
-        srid_from = 4326
-        srid_to = 21781
-        coords = _transform_point([7.37840, 45.91616], srid_from, srid_to)
-        self.assertEqual(int(coords[0]), 595324)  # pylint: disable=unsubscriptable-object
-        self.assertEqual(int(coords[1]), 84952)  # pylint: disable=unsubscriptable-object
 
     def get_precision_for_proj(self):
         # rounding all coordinates for to about 0.1 meter


### PR DESCRIPTION
Some search results might call the `transform_round_geometry` several times with
the same arguments. This function is quite slow (~50ms per call) so calling it
several times can have a significant impact.
For example the following request `/rest/services/inspire/SearchServer?type=layers&searchText=wand&geometryFormat=geojson&sr=2056`, the results in the raw sphinxsearch provides 30 matches that will call `transform_round_geometry()` 30 times with the same arguments. We could change the code to call it only once but using the caching is much simpler.

Also the `pyproj.transform()` method is deprecated and slower than the new method using `pyproj.Transformer`, therefore make use of `pyproj.Transformer`. Transforming one coordinate using `Transformer` is about ~2ms quicker than with `transform()`, for multiple coordinate the time gain is even bigger. Using the `Transformer` (without caching) improved the above request time from ~500ms ! Because creating a `Transformer` is quite time consuming (~6.5ms) we put it in a method using caching as well.

Overall with this PR the request in example above running locally using sphinxsearch on PROD (Ireland) we have the following perf

```
BASE_URL=http://localhost:5000 ITERATIONS=50 python3  -m test_search_perf
Did 50 iterations with 0 errors
avg=0.222, min=0.169, max=0.287
```
In comparison without the caching and uses of Transformer we had

```
BASE_URL=http://localhost:5000 ITERATIONS=50 python3  -m test_search_perf
Did 50 iterations with 0 errors
avg=1.635, min=1.498, max=1.753
```

So overall with this PR we have a performance gain of factor ~7.3x