### PR TITLE
BGDIINF_SB-2299: Fixed crash upon `type=location` search

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -590,7 +590,7 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
             else:
                 try:
                     pnt = (res['y'], res['x'])
-                    x, y, _ = transformer.transform(pnt[0], pnt[1])
+                    x, y = transformer.transform(pnt[0], pnt[1])
                     res['x'] = x
                     res['y'] = y
                 except (pyproj.exceptions.CRSError) as error:


### PR DESCRIPTION
The `Transformer.transform()` only returns x and y, due to `always_xy=True` in Transformer parameter.