### PR TITLE
BGDIINF_SB-2322: Made the sphinxapi timeout configurable and improved exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The service is configured by Environment Variable:
 | GEODATA_STAGING | prod | In the database bod, a dataset itself has the attribute staging. This staging (dev, int and prod) is being filtered when querying the indexes. |
 | SEARCH_SPHINX_HOST | localhost | The host for sphinx search server. |
 | SEARCH_SPHINX_PORT | 9321 | The port for sphinx search server. |
+| SEARCH_SPHINX_TIMEOUT | 3 | Sphinx server timeout |
 | CACHE_DEFAULT_TIMEOUT | 86400 | The time in seconds in which the db queries for `topics` and `translations` will be cached. Default 24 hours, as changing rarely. |
 | LOGGING_CFG | logging-cfg-local.yml | Logging configuration file |
 | FORWARED_ALLOW_IPS | `*` | Sets the gunicorn `forwarded_allow_ips` (see https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips). This is required in order to `secure_scheme_headers` to works. |
@@ -169,3 +170,4 @@ The service is configured by Environment Variable:
 | SCRIPT_NAME | '' | The script name. This will be used once, when we have an idea about how to query search-wsgi later on. F.ex. `/api/search/` f.ex. used by gunicorn (wsgi-server). |
 | CACHE_CONTROL_HEADER | `'public, max-age=600'` | Cache-Control header value for the search endpoint |
 | GZIP_COMPRESSION_LEVEL | `9` | GZIP compression level |
+| WSGI_TIMEOUT | 1 | WSGI timeout, note the final timout used is `SEARCH_SPHINX_TIMEOUT + WSGI_TIMEOUT`, so `WSGI_TIMEOUT` should the maximum amount of time that the WSGI app should have to handle the data received from sphinx server. |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -94,7 +94,10 @@ def log_response(response):
 def handle_exception(err):
     """Return JSON instead of HTML for HTTP errors."""
     if isinstance(err, HTTPException):
-        logger.error(err)
+        if err.code >= 500:
+            logger.exception(err)
+        else:
+            logger.error(err)
         return make_error_msg(err.code, err.description)
 
     logger.exception('Unexpected exception: %s', err)

--- a/app/lib/sphinxapi.py
+++ b/app/lib/sphinxapi.py
@@ -219,8 +219,8 @@ class SphinxClient:
         """
         Set connection timeout ( float second )
         """
-        assert isinstance(timeout, float)
-        # set timeout to 0 make connaection non-blocking that is wrong
+        assert isinstance(timeout, (float, int))
+        # set timeout to 0 make connection non-blocking that is wrong
         # so timeout got clipped to reasonable minimum
         self._timeout = max(0.001, timeout)
 

--- a/app/search.py
+++ b/app/search.py
@@ -27,6 +27,7 @@ from app.lib import sphinxapi
 from app.settings import GEODATA_STAGING
 from app.settings import SEARCH_SPHINX_HOST
 from app.settings import SEARCH_SPHINX_PORT
+from app.settings import SEARCH_SPHINX_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +139,7 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
 
     # is being called from routes.py directly
     def search(self):
-        self.sphinx.SetConnectTimeout(10.0)
+        self.sphinx.SetConnectTimeout(SEARCH_SPHINX_TIMEOUT)
         # create a quadindex if the bbox is defined
         if self.bbox is not None and self.typeInfo not in ('layers', 'featuresearch'):
             self._get_quad_index()

--- a/app/settings.py
+++ b/app/settings.py
@@ -65,6 +65,7 @@ FALLBACK_TOPICS = [
 
 SEARCH_SPHINX_HOST = os.getenv('SEARCH_SPHINX_HOST', 'localhost')
 SEARCH_SPHINX_PORT = int(os.getenv('SEARCH_SPHINX_PORT', '9312'))
+SEARCH_SPHINX_TIMEOUT = int(os.getenv('SEARCH_SPHINX_TIMEOUT', '3'))
 
 SCRIPT_NAME = os.getenv('SCRIPT_NAME', '')  # This is used by unicorn for route prefix
 
@@ -93,3 +94,5 @@ FORWARDED_PROTO_HEADER_NAME = os.getenv('FORWARDED_PROTO_HEADER_NAME', 'X-Forwar
 CACHE_CONTROL_HEADER = os.getenv('CACHE_CONTROL_HEADER', 'public, max-age=600')
 
 GZIP_COMPRESSION_LEVEL = int(os.getenv('GZIP_COMPRESSION_LEVEL', '9'))
+
+WSGI_TIMEOUT = int(os.getenv('WSGI_TIMEOUT', '1'))

--- a/wsgi.py
+++ b/wsgi.py
@@ -5,6 +5,8 @@ from app.helpers.utils import get_logging_cfg
 from app.settings import FORWARDED_PROTO_HEADER_NAME
 from app.settings import FORWARED_ALLOW_IPS
 from app.settings import HTTP_PORT
+from app.settings import SEARCH_SPHINX_TIMEOUT
+from app.settings import WSGI_TIMEOUT
 
 
 class StandaloneApplication(BaseApplication):  # pylint: disable=abstract-method
@@ -33,7 +35,7 @@ if __name__ == '__main__':
         'bind': f"0.0.0.0:{HTTP_PORT}",
         'worker_class': 'gevent',
         'workers': 2,  # scaling horizontally is left to Kubernetes
-        'timeout': 60,
+        'timeout': WSGI_TIMEOUT + SEARCH_SPHINX_TIMEOUT,
         'logconfig_dict': get_logging_cfg(),
         'forwarded_allow_ips': FORWARED_ALLOW_IPS,
         'secure_scheme_headers': {


### PR DESCRIPTION
@procrastinatio @rebert @ltclm @gjn does anyone remember why for 8 years ago we changed the sphinx server timeout from 3.5 seconds to 10 seconds (see https://github.com/geoadmin/mf-chsdi3/commit/7182778be3e268947cc40d2ab6ae5fc72e176d05) ? I found the 10 seconds too high who wants to wait 10 seconds on a search results ? Is there any known use case where the sphinx server needs that long to answer a search request ? 