### PR TITLE
BGDIINF_SB-2322: Sets the wsgi default workers to the double of CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The service is configured by Environment Variable:
 | Env         | Default               | Description                |
 | ----------- | --------------------- | -------------------------- |
 | HTTP_PORT | 5000 | The port on which the service can be queried. |
+| SEARCH_WORKERS | `0` | Number of workers. `0` or negative value means that the number of worker are computed from the number of cpu |
 | TESTING | False | When TESTING=True, the application does not need a db connection to retrieve a list of topics. A list with the topics used in the tests is being set. |
 | BOD_DB_NAME | - | Depending on the staging level usually |
 | BOD_DB_HOST | - | The db host. |

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,6 +17,8 @@ LOGS_DIR = os.getenv('LOGS_DIR', str(BASE_DIR / 'logs'))
 os.environ['LOGS_DIR'] = LOGS_DIR  # Set default if not set
 LOGGING_CFG = os.getenv('LOGGING_CFG', 'logging-cfg-local.yml')
 TRAP_HTTP_EXCEPTIONS = True
+SEARCH_WORKERS = int(os.getenv('SEARCH_WORKERS', '0'))
+
 BOD_DB_NAME = os.getenv('BOD_DB_NAME', None)
 BOD_DB_HOST = os.getenv('BOD_DB_HOST', None)
 BOD_DB_PORT = int(os.getenv('BOD_DB_PORT', '5432'))

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,3 +1,5 @@
+import multiprocessing
+
 from gunicorn.app.base import BaseApplication
 
 from app import app as application
@@ -30,11 +32,13 @@ class StandaloneApplication(BaseApplication):  # pylint: disable=abstract-method
 
 # We use the port 5000 as default, otherwise we set the HTTP_PORT env variable within the container.
 if __name__ == '__main__':
+    if SEARCH_WORKERS <= 0:
+        SEARCH_WORKERS = (multiprocessing.cpu_count() * 2) + 1
     # Bind to 0.0.0.0 to let your app listen to all network interfaces.
     options = {
         'bind': f"0.0.0.0:{HTTP_PORT}",
         'worker_class': 'gevent',
-        'workers': 2,  # scaling horizontally is left to Kubernetes
+        'workers': SEARCH_WORKERS,
         'timeout': WSGI_TIMEOUT + SEARCH_SPHINX_TIMEOUT,
         'logconfig_dict': get_logging_cfg(),
         'forwarded_allow_ips': FORWARED_ALLOW_IPS,


### PR DESCRIPTION
By default use the number of CPU to set the wsgi workers, however this value
    can be set to a fix value by configuration settings.
    
    Usually the number of workers depends on the deployment, for example on k8s
    scalling is done horizontally by k8s, while on vhost scaling is done vertically.