### PR TITLE
BGDIINF_SB-2752: wrong bbox input parameter will be responded with 400 - #minor

### DIFF
--- a/app/helpers/validation_search.py
+++ b/app/helpers/validation_search.py
@@ -144,7 +144,6 @@ class SearchValidation(MapNameValidation):  # pylint: disable=too-many-instance-
                 logger.error(msg)
                 raise BadRequest(msg)
             try:
-                # Python 2/3
                 values = list(map(float_raise_nan, values))
             except ValueError as e:
                 msg = f"Please provide numerical values for the parameter bbox and not {value}"
@@ -164,7 +163,6 @@ class SearchValidation(MapNameValidation):  # pylint: disable=too-many-instance-
                     logger.error(msg)
                     raise BadRequest(msg)
             try:
-                # Python 2/3
                 is_box2d(values)
             except ValueError as e:
                 msg = f"Please provide a valid bbox and not {values}"

--- a/app/helpers/validation_search.py
+++ b/app/helpers/validation_search.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import BadRequest
 from app.helpers.db import get_topics
 from app.helpers.helpers_search import float_raise_nan
 from app.helpers.helpers_search import ilen
+from app.helpers.helpers_search import is_box2d
 from app.helpers.helpers_search import shift_to
 from app.settings import SUPPORTED_LANGUAGES
 
@@ -162,6 +163,14 @@ class SearchValidation(MapNameValidation):  # pylint: disable=too-many-instance-
                     msg = "The third coordinate must be higher than the fourth"
                     logger.error(msg)
                     raise BadRequest(msg)
+            try:
+                # Python 2/3
+                is_box2d(values)
+            except ValueError as e:
+                msg = f"Please provide a valid bbox and not {values}"
+                logger.error("%s, %s", msg, e)
+                raise BadRequest(msg) from e
+
             self._bbox = values
 
     @timeInstant.setter


### PR DESCRIPTION
invalid bbox requests like:
https://sys-api3.prod.bgdi.ch/rest/services/ech/SearchServer?searchText=eifacheppis&bbox=2568780.73,1104389.74,2575100.88,1096769.83&origin=address&type=locations
will be responded with 400 status.