### PR TITLE
PB-299: fix missin results in queries on distributed swisssearch index

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -209,6 +209,8 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
         # Filter by origins if needed
         if self.origins is None:
             self._detect_keywords()
+            # by default filter all available origins/ranks
+            self.sphinx.SetFilter('rank', [1, 2, 3, 4, 5, 6, 7, 10])
         else:
             self._filter_locations_by_origins()
 
@@ -232,7 +234,7 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
                 # standard wildcard search
                 self.sphinx.AddQuery(searchTextFinal, index='swisssearch')
 
-            # exact search, first 10 results
+            # exact prefix search, first 10 results
             searchText = '@detail "^{}"'.format(' '.join(self.searchText))  # pylint: disable=consider-using-f-string
             self.sphinx.AddQuery(searchText, index='swisssearch')
 


### PR DESCRIPTION
when doing queries on the swisssearch distributed index which consists of the following parts:
```
        type = distributed
        local = zipcode         -> rank 1
        local = district        -> rank 3
        local = kantone         -> rank 4
        local = gg25            -> rank 2
        local = swissnames3d    -> rank 5
        local = haltestellen    -> rank 6
        local = parcel          -> rank 10
        local = address         -> rank 7
```

not all parts of the index are returned in the results when the request is sent without origins parameter which is the default.

The coverage of all the parts of the distributed index in the result can be forced by setting the filter to all the ranks that are available.

NOTE: it is unknown why the problem has been occurring since 18/02/2024.