### PR TITLE
PB-1167: fix issues / improve fuzzy search with quorum operator - #patch

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -509,7 +509,8 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
             def convert_if_digit(text):
                 if isdigit(text):
                     digit = re.findall(r'^\d+', text)[0]
-                    return f'({str(digit)}|{text})'
+                    if digit != text:
+                        return f'({str(digit)}|{text})'
                 return text
 
             def generate_prefixes(input_list, min_length=5):

--- a/app/search.py
+++ b/app/search.py
@@ -537,21 +537,20 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
                         input_list: A list of strings.
 
                     Returns:
-                        The maximum length of text elements, or 0 if no text elements are found.
+                        The maximum length of text elements, or None if no text elements are found.
                     """
-                    max_length = 0
-                    for element in input_list:
-                        if not isdigit(element):
-                            max_length = max(max_length, len(element))
-                    return max_length
+                    list_length = [len(a) for a in input_list if not isdigit(a)]
+                    return max(list_length) if list_length else None
 
                 result = []
 
-                if max_text_length(input_list) == 0:
-                    for text in input_list:
-                        result.append(convert_if_digit(text))
-                    return ' '.join(result)
+                if not max_text_length(input_list):
+                    return " ".join([convert_if_digit(x) for x in input_list])
 
+                # the while loop here loops through the list of all the keywords
+                # on every iteration the text keywords are trimmed by one characater
+                # the digit keywords are ignored
+                # this will be done until the max length of all keywords has reached min_length
                 while max_text_length(input_list) > min_length:
                     for i, text in enumerate(input_list):
                         if not isdigit(text) and len(text) >= min_length:

--- a/app/search.py
+++ b/app/search.py
@@ -507,6 +507,20 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
             minLength = 5
 
             def convert_if_digit(text):
+                """
+                replaces a keyword that begins with a digit the following sphinx query:
+                (digit|digit+rest)
+                examples:
+                    4a          -> (4|4a)
+                    342         -> (342)
+                    sometext    -> sometext
+                Args:
+                    text
+
+                Returns:
+                    sphinx query for digit and digit+rest if the keywords starts with a digit
+                    otherwise the input text will be returned unchanged
+                """
                 if isdigit(text):
                     digit = re.findall(r'^\d+', text)[0]
                     if digit != text:


### PR DESCRIPTION
the following issues have been solved:

1. digit prefix
p.e. `searchText=Chemin des Abeilles 4a 1304 Senarclens` will return fuzzy search results with the correct address `Chemin des Abeilles 4 1304 Senarclens` this can be achieved by replacing the search word `4a` with this search pattern `(4|4a)`

2. typo in the middle of the word
p.e. `searchText=Seftigernstrasse 264` will return fuzzy search results with the correct address `Seftigenstrasse 264`

the fuzzy search should have been generally improved with this change. Until now the only fuzzyness is the usage of metaphone codes for the matches. if a typo generates a different metaphone code there will be no matches. 

with the usage of the quorum operator [1] we can activate real fuzzy matching on whole query text level. metaphone codes are only adding fuzzyness on keyword level.


with these two changes in place:

```
searchText=Chemin des Abeillllles 4a 1304 Senarclens
searchText=['Chemin', 'des', 'Abeillllles', '4a', '1304', 'Senarclens']

-- will be converted and added to the final query text as:

| @detail "Chemin des Abeillllles (4|4a) (1304|1304) Senarclens"/0.7
```

```
searchText=Seftigernstrasse 264 wabern
searchText=['Seftigernstrasse', '264', 'Wabern' ]

-- will be converted and added to the final query text as:
| @detail "Seftigernstrasse (264|264) wabern"/0.7
```

if only one word is in the query text, the quorum operator is not adding any fuzziness. That's why the keyword will be trimmed character by character until it has a minimal length of 5 characters and added to the final query
```
searchText=Ssersddsdf
searchText=['Ssersddsdf']

-- will be converted into
[2024-12-09 08:29:21,945] DEBUG    - app.search                 : DEBUG ['Ssersddsd'] 9
[2024-12-09 08:29:21,946] DEBUG    - app.search                 : DEBUG ['Ssersdds'] 8
[2024-12-09 08:29:21,947] DEBUG    - app.search                 : DEBUG ['Ssersdd'] 7
[2024-12-09 08:29:21,948] DEBUG    - app.search                 : DEBUG ['Ssersd'] 6
[2024-12-09 08:29:21,949] DEBUG    - app.search                 : DEBUG ['Ssers'] 5

and added to the final query text as:
| @detail "Ssersddsdf"/0.7 | @detail ((Ssersddsd) | (Ssersdds) | (Ssersdd) | (Ssersd) | (Ssers))
```

[1] https://sphinxsearch.com/docs/archives/manual-2.2.10.html#extended-syntax