### PR TITLE
PB-1167: change fuzzy search ranker from sph04 to bm25 - #minor

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -166,11 +166,11 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
         logger.debug("Search fuzzy; searchText=%s", searchTextFinal)
         # We use different ranking for fuzzy search
         # For ranking modes, see http://sphinxsearch.com/docs/current.html#weighting
-        self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_SPH04)
+        self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_BM25)
         # Only include results with a certain weight. This might need tweaking
         # with the quorum operator lesser weights should be added to the results for the better
         # support of fuzziness
-        self.sphinx.SetFilterRange('@weight', 2500, 2**32 - 1)
+        self.sphinx.SetFilterRange('@weight', 1000, 2**32 - 1)
         try:
             if self.typeInfo in ('locations'):
                 results = self.sphinx.Query(searchTextFinal, index='swisssearch_fuzzy')


### PR DESCRIPTION
with the introduction of the quorum operator it makes sense to change the ranker/weighting to the bm25 method.

This should generate more natural order of the search results by applying the same weight to all the keywords in the search Text


p.e when searching for `via cantonale 20a 6949 Comano` the address `via cantonale 20 6949 Comano` should be on first position of the results. with the sph04 ranker this is not the case:

```
## SPH04 ranker current solution
MySQL [(none)]> SELECT *, weight() FROM address_metaphone WHERE match('@detail "via cantonale (20|20a) 6949 Comano"/0.7') OPTION ranker=sph04, max_matches=4 \GSHOW META;
*************************** 1. row ***************************
                id: 2543960
        feature_id: 191910623_0
            detail: via cantonale 1254d.99 6949 comano 5176 comano ch ti
             label: Via Cantonale 1254d.99 <b>6949 Comano</b>
       objectclass:
            origin: address
    geom_quadindex: 032033132103211100212
     geom_st_box2d: BOX(717525.4771268258 99021.01906243764,717525.4771268258 99021.01906243764)
geom_st_box2d_lv95: BOX(2717525.723 1099019.933,2717525.723 1099019.933)
              rank: 7
                 x: 99021.015625
                 y: 717525.500000
            y_lv95: 2717525.750000
            x_lv95: 1099019.875000
               lat: 46.032494
               lon: 8.956606
               num: 125499
         zoomlevel: 10
          weight(): 18561
*************************** 2. row ***************************
                id: 1845576
        feature_id: 11137707_0
            detail: via cantonale 20 6949 comano 5176 comano ch ti
             label: Via Cantonale 20 <b>6949 Comano</b>
       objectclass:
            origin: address
    geom_quadindex: 032033132101232110210
     geom_st_box2d: BOX(717503.7118818676 99167.84423624173,717503.7118818676 99167.84423624173)
geom_st_box2d_lv95: BOX(2717503.96 1099166.76,2717503.96 1099166.76)
              rank: 7
                 x: 99167.843750
                 y: 717503.687500
            y_lv95: 2717504.000000
            x_lv95: 1099166.750000
               lat: 46.033817
               lon: 8.956362
               num: 20
         zoomlevel: 10
          weight(): 14565

## BM25 ranker new solution
MySQL [(none)]> SELECT *, weight() FROM address_metaphone WHERE match('@detail "via cantonale (20|20a) 6949 Comano"/0.7') OPTION ranker=bm25, max_matches=4 \GSHOW META;
*************************** 1. row ***************************
                id: 1845576
        feature_id: 11137707_0
            detail: via cantonale 20 6949 comano 5176 comano ch ti
             label: Via Cantonale 20 <b>6949 Comano</b>
       objectclass:
            origin: address
    geom_quadindex: 032033132101232110210
     geom_st_box2d: BOX(717503.7118818676 99167.84423624173,717503.7118818676 99167.84423624173)
geom_st_box2d_lv95: BOX(2717503.96 1099166.76,2717503.96 1099166.76)
              rank: 7
                 x: 99167.843750
                 y: 717503.687500
            y_lv95: 2717504.000000
            x_lv95: 1099166.750000
               lat: 46.033817
               lon: 8.956362
               num: 20
         zoomlevel: 10
          weight(): 1565
*************************** 2. row ***************************
                id: 853872
        feature_id: 191380650_0
            detail: via cantonale 4 6949 comano 5176 comano ch ti
             label: Via Cantonale 4 <b>6949 Comano</b>
       objectclass:
            origin: address
    geom_quadindex: 032033132103320002112
     geom_st_box2d: BOX(717542.2808840257 98960.63077667744,717542.2808840257 98960.63077667744)
geom_st_box2d_lv95: BOX(2717542.526 1098959.544,2717542.526 1098959.544)
              rank: 7
                 x: 98960.632812
                 y: 717542.250000
            y_lv95: 2717542.500000
            x_lv95: 1098959.500000
               lat: 46.031948
               lon: 8.956808
               num: 4
         zoomlevel: 10
          weight(): 1561          
```

:warning: the absolute values of the weight attribute will change with this.