### PR TITLE
PB-2156: prioritize exact matches in featuresearch results - #patch

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -541,12 +541,20 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
         if hasDigit:
             prefix_digit = lambda x: x if not isdigit(x) else ''.join((x, '*'))
             prefix_all = lambda x: ''.join((x, '*'))
+            exactAll = ' '.join(self.searchText)
             preDigit = ' '.join([prefix_digit(w) for w in self.searchText])
             preNonDigitAndPreDigit = ' '.join([prefix_all(w) for w in self.searchText])
             infNonDigitAndPreDigit = ' '.join([
                 prefix_digit(infix_non_digit(w)) for w in self.searchText
             ])
-            q = q + [
+            q = [
+                # Exact matches first (highest priority for ranking)
+                f'{fields} "{exactAll}"',
+                f'{fields} "^{exactAll}"',
+                f'{fields} "{exactAll}$"',
+                f'{fields} "^{exactAll}$"',
+            ] + q + [
+                # Then prefix matches
                 f'{fields} "{preDigit}"',
                 f'{fields} "^{preDigit}"',
                 f'{fields} "{preNonDigitAndPreDigit}"',
@@ -753,6 +761,23 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
                         del match['attrs']['lang']
                     if 'agnostic' in match['attrs']:
                         del match['attrs']['agnostic']
+
+                    # Boost exact matches in detail field
+                    # Similar to swiss search exact match boosting
+                    if self.searchText:
+                        detail = match['attrs'].get('detail', '').lower()
+                        search_text_joined = ' '.join(self.searchText).lower()
+                        # Check if detail contains exact match as a word boundary
+                        # (at start, end, or surrounded by spaces)
+                        if (
+                            detail == search_text_joined or
+                            detail.startswith(f"{search_text_joined} ") or
+                            detail.endswith(f" {search_text_joined}") or
+                            f" {search_text_joined} " in detail
+                        ):
+                            # Boost weight significantly for exact word matches
+                            match['weight'] += 10000
+
                     if not self.bbox or self._bbox_intersection(
                         self.bbox, match['attrs']['geom_st_box2d']
                     ):


### PR DESCRIPTION
- Add exact match queries (without wildcards) for digit-based searches
  in addition to prefix match queries
- Boost weight by +10000 for results where searchText appears as an
  exact word in the detail field (matching at word boundaries)
- Ensures exact code matches (e.g., "111001") are ranked at the top
  even when surrounded by other text in the detail field
- Fixes issue where all prefix matches had identical weight of 4

`rest/services/ech/SearchServer?searchText=111001&type=featuresearch&features=ch.bfs.gebaeude_wohnungs_register`

```json
{
  "results": [
    {
      "attrs": {
        "detail": "via valle verzasca 7 6632 vogorno verzasca _ti_ 11100130",
        "featureId": "11100130_0",
        "feature_id": "11100130_0",
        "geom_quadindex": "032031010211321121113",
        "geom_st_box2d": "BOX(709621.1369603279 118878.52939728371,709621.1369603279 118878.52939728371)",
        "label": "Via Valle Verzasca 7 Verzasca",
        "lat": 46.212425231933594,
        "layer": "ch.bfs.gebaeude_wohnungs_register",
        "lon": 8.859180450439453,
        "origin": "feature"
      },
      "id": 9367,
      "weight": 4
    },
    ...
```
will be replaced with

```json
{
  "results": [
    {
      "attrs": {
        "detail": "raeterschenstrasse 10 8418 schlatt zh schlatt _zh_ _zh_ 111001",
        "featureId": "111001_0",
        "feature_id": "111001_0",
        "geom_quadindex": "030010313122220212210",
        "geom_st_box2d": "BOX(704071.1685604602 259725.79746988925,704071.1685604602 259725.79746988925)",
        "label": "Räterschenstrasse 10 Schlatt (ZH)",
        "lat": 47.48006057739258,
        "layer": "ch.bfs.gebaeude_wohnungs_register",
        "lon": 8.819401741027832,
        "origin": "feature"
      },
      "id": 1741256,
      "weight": 10008
    },
    ...
```