### PR TITLE
BGDIDIC-154: use EGAID as feature ID in links section 

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -738,9 +738,6 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
 
             # Add related links for address results (including metaphone)
             # Only add the links section if both new attributes exist
-            # TODO: PB-2168 once the featureid in mf-chsdi of  # pylint: disable=fixme
-            # ch.swisstopo.amtliches-gebaeudeadressverzeichnis has been switched
-            # back to egaid, we can do the same here in the links section
             if origin in ('address', 'address_metaphone'):
                 egaid = result['attrs'].get('egaid')
                 egid_edid = result['attrs'].get('egid_edid')
@@ -752,7 +749,7 @@ class Search(SearchValidation):  # pylint: disable=too-many-instance-attributes
                             'href': (
                                 f"/rest/services/ech/MapServer/"
                                 f"ch.swisstopo.amtliches-gebaeudeadressverzeichnis/"
-                                f"{egid_edid}"
+                                f"{egaid}"
                             )
                         },
                         {

--- a/tests/unit_tests/test_address_links.py
+++ b/tests/unit_tests/test_address_links.py
@@ -74,7 +74,7 @@ class TestAddressLinksComprehensive(unittest.TestCase):
         hrefs = {link['href'] for link in result['links']}
         self.assertIn(
             '/rest/services/ech/MapServer/'
-            'ch.swisstopo.amtliches-gebaeudeadressverzeichnis/EGID_EDID_001',
+            'ch.swisstopo.amtliches-gebaeudeadressverzeichnis/EGAID_001',
             hrefs,
         )
         self.assertIn(


### PR DESCRIPTION
for address results

- Changed feature ID in address links from egid_edid to egaid
- Removed TODO comment for PB-2168 as backend switch is complete
- Updated test expectations to match new feature ID format